### PR TITLE
Support unity code coverage package.

### DIFF
--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -82,6 +82,10 @@ if [ $EDIT_MODE = true ]; then
       -runTests \
       -testPlatform editmode \
       -testResults "$FULL_ARTIFACTS_PATH/editmode-results.xml" \
+      -enableCodeCoverage \
+      -coverageResultsPath "$FULL_ARTIFACTS_PATH/CodeCoverage/" \ 
+      -coverageOptions "generateHtmlReport;assemblyFilters:-*unity*" \
+      -burst-disable-compilation 
       $CUSTOM_PARAMETERS
       
   # Catch exit code
@@ -120,6 +124,10 @@ if [ $PLAY_MODE = true ]; then
       -runTests \
       -testPlatform playmode \
       -testResults "$FULL_ARTIFACTS_PATH/playmode-results.xml" \
+      -enableCodeCoverage \
+      -coverageResultsPath "$FULL_ARTIFACTS_PATH/CodeCoverage/" \
+      -coverageOptions "generateHtmlReport;assemblyFilters:-*unity*" \
+      -burst-disable-compilation 
       $CUSTOM_PARAMETERS
       
   # Catch exit code


### PR DESCRIPTION
First off; awesome project we've found it super useful. Thanks for building, sharing and maintaining it so well!

Unity now has a great [code coverage package](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@0.2/manual/CoverageTestRunner.html) now available and we're big on testing at AIR so we're using it. Naturally we want to integrate this as a quality gate with our existing github actions, which makes use of your project. To do that we've added the new code coverage arguments to the unity arguments as you can see in our amendments to [run_tests.sh](https://github.com/webbertakken/unity-test-runner/compare/master...AnImaginedReality:master#diff-2abcc3f049b9f46d949f8ef1f5849c4d).

It's worth noting that we've tested this with a project that doesn't use the above package, and the arguments where simply ignored.

Once the artifacts contain the code coverage report, we then parse it with our own github action job, found here: https://github.com/AnImaginedReality/UnityCodeCoverage.Action.

We'll probably continue to improve and maintain the UnityCodeCoverage.Action repo, and wanted to thank you for your great work building and maintaining this project so far.
