### PR TITLE
secure license

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,9 @@
 name: Actions 😎
 on:
-  pull_request_target: {}
   push: { branches: [master] }
+  pull_request_target:
+    paths-ignore:
+      - ".github/**"
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,7 @@
 name: Actions 😎
 on:
-  pull_request: {}
+  pull_request_target: {}
   push: { branches: [master] }
-
-env:
-  UNITY_LICENSE: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\n    <License id=\"Terms\">\n        <MachineBindings>\n            <Binding Key=\"1\" Value=\"d39b8e2f4d364b2e98b06afa0c6e08c5\"/>\n            <Binding Key=\"2\" Value=\"d39b8e2f4d364b2e98b06afa0c6e08c5\"/>\n        </MachineBindings>\n        <MachineID Value=\"Xxo1ZKbdPu/IATrc0mPBYANJFF0=\"/>\n        <SerialHash Value=\"1efd68fa935192b6090ac03c77d289a9f588c55a\"/>\n        <Features>\n            <Feature Value=\"33\"/>\n            <Feature Value=\"1\"/>\n            <Feature Value=\"12\"/>\n            <Feature Value=\"2\"/>\n            <Feature Value=\"24\"/>\n            <Feature Value=\"3\"/>\n            <Feature Value=\"36\"/>\n            <Feature Value=\"17\"/>\n            <Feature Value=\"19\"/>\n            <Feature Value=\"62\"/>\n        </Features>\n        <DeveloperData Value=\"AQAAAEY0LUg2WFMtUE00NS1SM0M4LUUyWlotWkdWOA==\"/>\n        <SerialMasked Value=\"F4-H6XS-PM45-R3C8-E2ZZ-XXXX\"/>\n        <StartDate Value=\"2018-05-02T00:00:00\"/>\n        <UpdateDate Value=\"2019-11-25T18:23:38\"/>\n        <InitialActivationDate Value=\"2018-05-02T14:21:28\"/>\n        <LicenseVersion Value=\"6.x\"/>\n        <ClientProvidedVersion Value=\"2019.2.11f1\"/>\n        <AlwaysOnline Value=\"false\"/>\n        <Entitlements>\n            <Entitlement Ns=\"unity_editor\" Tag=\"UnityPersonal\" Type=\"EDITOR\" ValidTo=\"9999-12-31T00:00:00\"/>\n        </Entitlements>\n    </License>\n<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments\"/><SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/><Reference URI=\"#Terms\"><Transforms><Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/></Transforms><DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\"/><DigestValue>JHdOBFmBNq2H8BrGFzir/StLoYo=</DigestValue></Reference></SignedInfo><SignatureValue>aENLHd37a51RtP2/g7YU0Pexf5mx0/ENXYGtrPzqwZ8NQt2AsSdxGnl0CUB45/GuNXfJVDt2HWot\ncNYZB2OylVBn1WHQbKZlPmm8gEAMz0MYbr4Isb5i5buryBrZlmbEOjnRI+pEg1CBwlgMo6xdtjjE\n/d7cC293QIUO91kdzRXftYou1dNaUyuPL9ZH65vdB2pDXGRNxgUVD+GnnqZA7b5L2HXqNQclcWAK\n5Yd1BeF3VzR1iLw9G/SmH5oOhnpXSmqbL4qk7LVP2/mgXpFk5kP4X8VC3z47obNhBIGq40dwWyEe\nUYk5/nRAOkZawDT+tcu96e06gPC9Cxk5PdbRbA==</SignatureValue></Signature></root>"
 
 jobs:
   tests:
@@ -35,9 +32,25 @@ jobs:
           - playmode
           - editmode
     steps:
-      - uses: actions/checkout@v2
+      ###########################
+      #         Checkout        #
+      ###########################
+      - name: Checkout (default)
+        uses: actions/checkout@v2
+        if: github.event.event_type != 'pull_request_target'
         with:
           lfs: true
+      - name: Checkout (pull_request_target)
+        uses: actions/checkout@v2
+        if: github.event.event_type == 'pull_request_target'
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      ###########################
+      #          Cache          #
+      ###########################
       - uses: actions/cache@v2
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -52,6 +65,8 @@ jobs:
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
           customParameters: -profile SomeProfile -someBoolean -someValue exampleValue
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
       - uses: actions/upload-artifact@v2
         with:
           name: Test results for ${{ matrix.testMode }}
@@ -69,13 +84,25 @@ jobs:
         unityVersion:
           - 2019.2.11f1
     steps:
-      # Checkout repository (required to test local actions)
-      - name: Checkout repository
+      ###########################
+      #         Checkout        #
+      ###########################
+      - name: Checkout (default)
         uses: actions/checkout@v2
+        if: github.event.event_type != 'pull_request_target'
         with:
           lfs: true
+      - name: Checkout (pull_request_target)
+        uses: actions/checkout@v2
+        if: github.event.event_type == 'pull_request_target'
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      # Enable caching
+      ###########################
+      #          Cache          #
+      ###########################
       - uses: actions/cache@v1.1.0
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -93,6 +120,8 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: all
           # Test implicit artifactsPath, by not setting it
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
       # Upload artifacts
       - name: Upload test results
@@ -113,13 +142,25 @@ jobs:
         projectPath:
           - unity-project-with-correct-tests
     steps:
-      # Checkout repository (required to test local actions)
-      - name: Checkout repository
+      ###########################
+      #         Checkout        #
+      ###########################
+      - name: Checkout (default)
         uses: actions/checkout@v2
+        if: github.event.event_type != 'pull_request_target'
         with:
           lfs: true
+      - name: Checkout (pull_request_target)
+        uses: actions/checkout@v2
+        if: github.event.event_type == 'pull_request_target'
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      # Enable caching
+      ###########################
+      #          Cache          #
+      ###########################
       - uses: actions/cache@v1.1.0
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -137,6 +178,8 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: editmode
           artifactsPath: artifacts/editmode
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
       # Upload artifacts
       - name: Upload test results
@@ -157,13 +200,25 @@ jobs:
         unityVersion:
           - 2019.2.11f1
     steps:
-      # Checkout repository (required to test local actions)
-      - name: Checkout repository
+      ###########################
+      #         Checkout        #
+      ###########################
+      - name: Checkout (default)
         uses: actions/checkout@v2
+        if: github.event.event_type != 'pull_request_target'
         with:
           lfs: true
+      - name: Checkout (pull_request_target)
+        uses: actions/checkout@v2
+        if: github.event.event_type == 'pull_request_target'
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      # Enable caching
+      ###########################
+      #          Cache          #
+      ###########################
       - uses: actions/cache@v1.1.0
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -181,6 +236,8 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: playmode
           artifactsPath: artifacts/playmode
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
       # Upload artifacts
       - name: Upload test results
@@ -201,13 +258,25 @@ jobs:
         projectPath:
           - unity-project-with-correct-tests
     steps:
-      # Checkout repository (required to test local actions)
-      - name: Checkout repository
+      ###########################
+      #         Checkout        #
+      ###########################
+      - name: Checkout (default)
         uses: actions/checkout@v2
+        if: github.event.event_type != 'pull_request_target'
         with:
           lfs: true
+      - name: Checkout (pull_request_target)
+        uses: actions/checkout@v2
+        if: github.event.event_type == 'pull_request_target'
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      # Enable caching
+      ###########################
+      #          Cache          #
+      ###########################
       - uses: actions/cache@v1.1.0
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -224,6 +293,8 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: editmode
           artifactsPath: artifacts/editmode
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
       # Configure second test runner
       - name: Tests in playmode 📺
@@ -233,6 +304,8 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: playmode
           artifactsPath: artifacts/playmode
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
       # Upload combined artifacts
       - name: Upload combined test results


### PR DESCRIPTION
#### Changes

- Use `pull_request_target` to run pull request workflow on the workflow of `main` to be able to use secrets.
- Move license to secrets
- Reduce exposure of ENV variables that hold secrets
- Checkout the code from the PR to run the tests against
- Ignore changes in github workflows as it can become rather confusing if you try to change a workflow, when it doesn't trigger on the PR itself, but on main only.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
