### PR TITLE
Run license activation in an empty directory

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
 
 #
+# Create directory for license activation
+#
+
+ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license"
+mkdir -p "$ACTIVATE_LICENSE_PATH"
+
+#
 # Run steps
 #
 
 source /steps/activate.sh
 source /steps/run_tests.sh
 source /steps/return_license.sh
+
+#
+# Remove license activation directory
+#
+
+rm -r "$ACTIVATE_LICENSE_PATH"
 
 #
 # Instructions for debugging

--- a/action/steps/activate.sh
+++ b/action/steps/activate.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Run in a new empty directory
+ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license"
+echo "Creating and changing to \"$ACTIVATE_LICENSE_PATH\" directory."
+mkdir -p "$ACTIVATE_LICENSE_PATH"
+pushd "$ACTIVATE_LICENSE_PATH"
+
 if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE"  ]]; then
   #
   # PERSONAL LICENSE MODE
@@ -102,3 +108,6 @@ else
   echo "Exit code was: $UNITY_EXIT_CODE"
   exit $UNITY_EXIT_CODE
 fi
+
+# Return to previous working directory
+popd

--- a/action/steps/activate.sh
+++ b/action/steps/activate.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Run in a new empty directory
-ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license"
-echo "Creating and changing to \"$ACTIVATE_LICENSE_PATH\" directory."
-mkdir -p "$ACTIVATE_LICENSE_PATH"
+# Run in ACTIVATE_LICENSE_PATH directory
+echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
 if [[ -n "$UNITY_LICENSE" ]] || [[ -n "$UNITY_LICENSE_FILE"  ]]; then

--- a/action/steps/return_license.sh
+++ b/action/steps/return_license.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # Run in ACTIVATE_LICENSE_PATH directory
-ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license"
 echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
 pushd "$ACTIVATE_LICENSE_PATH"
 
@@ -21,7 +20,3 @@ fi
 
 # Return to previous working directory
 popd
-
-# Deleting ACTIVATE_LICENSE_PATH directory
-echo "Deleting \"$ACTIVATE_LICENSE_PATH\" directory."
-rm -r "$ACTIVATE_LICENSE_PATH"

--- a/action/steps/return_license.sh
+++ b/action/steps/return_license.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Run in ACTIVATE_LICENSE_PATH directory
+ACTIVATE_LICENSE_PATH="$GITHUB_WORKSPACE/_activate-license"
+echo "Changing to \"$ACTIVATE_LICENSE_PATH\" directory."
+pushd "$ACTIVATE_LICENSE_PATH"
+
 if [[ -n "$UNITY_SERIAL" ]]; then
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
@@ -13,3 +18,10 @@ if [[ -n "$UNITY_SERIAL" ]]; then
     -quit \
     -returnlicense
 fi
+
+# Return to previous working directory
+popd
+
+# Deleting ACTIVATE_LICENSE_PATH directory
+echo "Deleting \"$ACTIVATE_LICENSE_PATH\" directory."
+rm -r "$ACTIVATE_LICENSE_PATH"


### PR DESCRIPTION
#### Changes

- Run the `activate` and `return_license` steps in a new empty directory to avoid Unity errors in package resolution.

Fixes game-ci/unity-actions#97

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
