### PR TITLE
Use exit code to fail when code compile fails

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -42,6 +42,6 @@ fi;
 # Exit with code from the build step.
 #
 
-if [ $USE_EXIT_CODE = true ]; then
+if [[ $USE_EXIT_CODE == true || $TEST_RUNNER_EXIT_CODE -ne 2 ]]; then
 exit $TEST_RUNNER_EXIT_CODE
 fi;


### PR DESCRIPTION
#### Changes

This is an alternative solution to https://github.com/game-ci/unity-test-runner/pull/137

Test compiler error: https://github.com/finol-digital/Card-Game-Simulator/actions/runs/1172309575
Test playMode test failure: https://github.com/finol-digital/Card-Game-Simulator/actions/runs/1172328015
Confirm successful test run:  https://github.com/finol-digital/Card-Game-Simulator/actions/runs/1172347925

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
