### PR TITLE
fix unary operator expected error

### DIFF
--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -160,7 +160,7 @@ if [ "$EDIT_MODE" == "true" ]; then
   cat "$FULL_ARTIFACTS_PATH/editmode-results.xml" | grep test-run | grep Passed
 fi
 
-if [ "$PLAY_MODE" == "true ]; then
+if [ "$PLAY_MODE" == "true" ]; then
   echo ""
   echo "###########################"
   echo "#    Play Mode Results    #"

--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -67,8 +67,9 @@ ls -alh $UNITY_PROJECT_PATH
 #
 # Testing in EditMode
 #
+EDIT_MODE_EXIT_CODE=0
 
-if [ $EDIT_MODE = true ]; then
+if [ "$EDIT_MODE" == "true" ]; then
   echo ""
   echo "###########################"
   echo "#   Testing in EditMode   #"
@@ -104,8 +105,8 @@ fi
 #
 # Testing in PlayMode
 #
-
-if [ $PLAY_MODE = true ]; then
+PLAY_MODE_EXIT_CODE=0
+if [ "$PLAY_MODE" == "true" ]; then
   echo ""
   echo "###########################"
   echo "#   Testing in PlayMode   #"
@@ -149,7 +150,7 @@ echo "###########################"
 echo ""
 ls -alh $UNITY_PROJECT_PATH
 
-if [ $EDIT_MODE = true ]; then
+if [ "$EDIT_MODE" == "true" ]; then
   echo ""
   echo "###########################"
   echo "#    Edit Mode Results    #"
@@ -159,7 +160,7 @@ if [ $EDIT_MODE = true ]; then
   cat "$FULL_ARTIFACTS_PATH/editmode-results.xml" | grep test-run | grep Passed
 fi
 
-if [ $PLAY_MODE = true ]; then
+if [ "$PLAY_MODE" == "true ]; then
   echo ""
   echo "###########################"
   echo "#    Play Mode Results    #"

--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -69,7 +69,7 @@ ls -alh $UNITY_PROJECT_PATH
 #
 EDIT_MODE_EXIT_CODE=0
 
-if [ "$EDIT_MODE" == "true" ]; then
+if [ "$EDIT_MODE" = "true" ]; then
   echo ""
   echo "###########################"
   echo "#   Testing in EditMode   #"
@@ -106,7 +106,7 @@ fi
 # Testing in PlayMode
 #
 PLAY_MODE_EXIT_CODE=0
-if [ "$PLAY_MODE" == "true" ]; then
+if [ "$PLAY_MODE" = "true" ]; then
   echo ""
   echo "###########################"
   echo "#   Testing in PlayMode   #"
@@ -150,7 +150,7 @@ echo "###########################"
 echo ""
 ls -alh $UNITY_PROJECT_PATH
 
-if [ "$EDIT_MODE" == "true" ]; then
+if [ "$EDIT_MODE" = "true" ]; then
   echo ""
   echo "###########################"
   echo "#    Edit Mode Results    #"
@@ -160,7 +160,7 @@ if [ "$EDIT_MODE" == "true" ]; then
   cat "$FULL_ARTIFACTS_PATH/editmode-results.xml" | grep test-run | grep Passed
 fi
 
-if [ "$PLAY_MODE" == "true" ]; then
+if [ "$PLAY_MODE" = "true" ]; then
   echo ""
   echo "###########################"
   echo "#    Play Mode Results    #"

--- a/action/steps/run_tests.sh
+++ b/action/steps/run_tests.sh
@@ -68,7 +68,6 @@ ls -alh $UNITY_PROJECT_PATH
 # Testing in EditMode
 #
 EDIT_MODE_EXIT_CODE=0
-
 if [ "$EDIT_MODE" = "true" ]; then
   echo ""
   echo "###########################"


### PR DESCRIPTION
The if comparisons can sometimes compare an empty variable, which gives errors like this:
```
/steps/run_tests.sh: line 71: [: =: unary operator expected
```

This PR should fix the script to address that problem. 
See an explanation of why this error happens here:
https://codefather.tech/blog/bash-unary-operator-expected/

#### Changes

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
