### PR TITLE
fix: operation not permitted in self hosted runners

### DIFF
--- a/src/model/docker.ts
+++ b/src/model/docker.ts
@@ -69,7 +69,7 @@ const Docker = {
         --env RUNNER_WORKSPACE \
         --env GIT_PRIVATE_TOKEN="${gitPrivateToken}" \
         ${sshAgent ? '--env SSH_AUTH_SOCK=/ssh-agent' : ''} \
-        --volume "/var/run/docker.sock":"/var/run/docker.sock:z" \
+        --volume "/var/run/docker.sock":"/var/run/docker.sock" \
         --volume "${githubHome}":"/root:z" \
         --volume "${githubWorkflow}":"/github/workflow:z" \
         --volume "${workspace}":"/github/workspace:z" \


### PR DESCRIPTION
Self hosted runners in fedora make the docker.sock a link to /run/podman/podman.sock

Trying to set the :z on docker.sock seems to randomly cause:
```
Error: lsetxattr /var/run/docker.sock: operation not permitted

Error: The process '/usr/bin/docker' failed with exit code 126
```
I think the :z may be broken for links?  hard to tell.

#### Changes

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
