### PR TITLE
Changed eableCyclomaticComplexity to generateAdditionalMetrics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           testMode: all
-          coverageOptions: 'enableCyclomaticComplexity;generateHtmlReport;generateBadgeReport;assemblyFilters:+MyScripts'
+          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+MyScripts'
           # Test implicit artifactsPath, by not setting it
 
       # Upload artifacts

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: 'The type of tests to be run by the test runner.'
   coverageOptions:
     required: false
-    default: 'enableCyclomaticComplexity;generateHtmlReport;generateBadgeReport'
+    default: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport'
     description: 'Optional coverage parameters for the -coverageOptions argument.'
   artifactsPath:
     required: false

--- a/unity-project-with-correct-tests/Packages/manifest.json
+++ b/unity-project-with-correct-tests/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.ide.vscode": "1.1.2",
     "com.unity.package-manager-ui": "2.2.0",
     "com.unity.test-framework": "1.0.13",
-    "com.unity.testtools.codecoverage": "1.0.1",
+    "com.unity.testtools.codecoverage": "1.1.1",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.1.0",
     "com.unity.ugui": "1.0.0",


### PR DESCRIPTION
#### Changes

Changed default parameter `enableCyclomaticComplexity` to `generateAdditionalMetrics` for default coverage options.

Responding to the update in the logs I forgot to update pointed out by @nikosatwork thanks for the catch! [comment link](https://github.com/game-ci/unity-test-runner/pull/182#discussion_r855260246)
> The `enableCyclomaticComplexity` option has been replaced with the `generateAdditionalMetrics` option since version 0.3.0 of the Code Coverage package
> 
> Source: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/changelog/CHANGELOG.html

And updated version of codecoverrage package in example project to be v1.1.1 since it's the most recent non-experimental release. 

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
