### PR TITLE
Add unityLicensingServer to action.yml so warning for input dissapears

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     required: false
     default: ''
     description: 'User and optionally group (user or user:group or uid:gid) to give ownership of the resulting build artifacts'
+  unityLicensingServer:
+    required: false
+    default: ''
+    description: 'Url to a unity license server for acquiring floating licenses.'
 outputs:
   artifactsPath:
     description: 'Path where the artifacts are stored.'


### PR DESCRIPTION
#### Changes

- Added unityLicensingServer to inputs for action. It gives a warning when used if not defined here. 

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x ] Readme (updated or not needed)
- [ x] Tests (added, updated or not needed)
