### PR TITLE
Added dontClear coverage flag to default coverage options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           testMode: all
-          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+MyScripts'
+          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+MyScripts;dontClear'
           # Test implicit artifactsPath, by not setting it
 
       # Upload artifacts

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: 'The type of tests to be run by the test runner.'
   coverageOptions:
     required: false
-    default: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport'
+    default: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;dontClear'
     description: 'Optional coverage parameters for the -coverageOptions argument.'
   artifactsPath:
     required: false


### PR DESCRIPTION
#### Changes

Added the `dontClear` flag to the default code coverage options.

As of version [1.2.0](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/changelog/CHANGELOG.html#features) of the CodeCoverage package, you need to use the `dontClear` flag to allow combining test results.

> Add this to allow coverage results to be accumulated after every code coverage session. If not passed the results are cleared before a new session. For more information see [Generate combined report from EditMode and PlayMode tests](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html#generate-combined-report-from-editmode-and-playmode-tests).

Will make a corresponding change to the documentation as well if this change works.

Tested this flag locally with my own repo - https://github.com/nicholas-maltbie/OpenKCC/pull/110

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
