### PR TITLE
Trims output length to avoid hitting github 2Mb limitation

### DIFF
--- a/src/model/results-check.ts
+++ b/src/model/results-check.ts
@@ -76,6 +76,14 @@ const ResultsCheck = {
     const pullRequest = github.context.payload.pull_request;
     const headSha = (pullRequest && pullRequest.head.sha) || github.context.sha;
 
+    const maxLen = 65534;
+    if(output.length > maxLen)
+    {
+      core.warning(`Output too long (${output.length}) truncating to ${maxLen}`);
+      output = output.substring(0, maxLen);
+    }
+
+
     core.info(`Posting results for ${headSha}`);
     const createCheckRequest = {
       ...github.context.repo,


### PR DESCRIPTION
#### Changes

- Truncates the output of output sent to `requestGitHubCheck` to respect the actual limitation of the platform.

Should fix #142 . Loosely related to #169 .

#### Discussion

For now the PR only truncates the output without filtering as suggested in #142 and #169. If a test is failed in the said 65534 bytes, the mark will be set to `fail`. I'm a bit sceptical about the solution, but that's still a improvement over just failing for an unrelated github-limit reason.

Of course, I'm open to other suggestions, such as implementing #169 fully if there is a concensus on it.

I'd gladly get some pointers for doing so, not being familiar with the ecosystem.
Thanks in advance :bow:

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
