### PR TITLE
Wrap "Project Directory" lines to fix dir/ls for paths with spaces

### DIFF
--- a/dist/steps/run_tests.ps1
+++ b/dist/steps/run_tests.ps1
@@ -51,7 +51,7 @@ Write-Output "###########################"
 Write-Output "#    Project directory    #"
 Write-Output "###########################"
 Write-Output ""
-Get-ChildItem -Hidden -Path $UNITY_PROJECT_PATH
+Get-ChildItem -Hidden -Path "$UNITY_PROJECT_PATH"
 
 #
 # Testing for each platform

--- a/dist/steps/run_tests.sh
+++ b/dist/steps/run_tests.sh
@@ -123,7 +123,7 @@ echo "###########################"
 echo "#    Project directory    #"
 echo "###########################"
 echo ""
-ls -alh $UNITY_PROJECT_PATH
+ls -alh "$UNITY_PROJECT_PATH"
 
 #
 # Testing for each platform


### PR DESCRIPTION
A very small commit to fix this one little tiny detail that's been bugging me and I imagine has been bugging many others too.

#### Changes

- Wrap `$UNITY_PROJECT_PATH` in quotes on lines 54 and 126 to properly `DIR`/`LS` paths with spaces respectively

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
