### PR TITLE
fix: add check before performing chmod on the code coverage path

### DIFF
--- a/dist/platforms/ubuntu/run_tests.sh
+++ b/dist/platforms/ubuntu/run_tests.sh
@@ -247,5 +247,5 @@ chmod -R a+r "$FULL_ARTIFACTS_PATH"
 if [ -d "$FULL_COVERAGE_RESULTS_PATH" ]; then
   chmod -R a+r "$FULL_COVERAGE_RESULTS_PATH"
 else
-  echo "Coverage results directory does not exist. If you are expecting coverage results, please make sure the Code Coverage package is installed in your project."
+  echo "Coverage results directory does not exist. If you are expecting coverage results, please make sure the Code Coverage package is installed in your project and that it is set up correctly."
 fi

--- a/dist/platforms/ubuntu/run_tests.sh
+++ b/dist/platforms/ubuntu/run_tests.sh
@@ -242,4 +242,10 @@ fi
 # Add read permissions for everyone to all artifacts
 chmod -R a+r "$UNITY_PROJECT_PATH"
 chmod -R a+r "$FULL_ARTIFACTS_PATH"
-chmod -R a+r "$FULL_COVERAGE_RESULTS_PATH"
+
+# Check if coverage results directory exists
+if [ -d "$FULL_COVERAGE_RESULTS_PATH" ]; then
+  chmod -R a+r "$FULL_COVERAGE_RESULTS_PATH"
+else
+  echo "Coverage results directory does not exist. If you are expecting coverage results, please make sure the Code Coverage package is installed in your project."
+fi

--- a/dist/platforms/ubuntu/run_tests.sh
+++ b/dist/platforms/ubuntu/run_tests.sh
@@ -247,5 +247,5 @@ chmod -R a+r "$FULL_ARTIFACTS_PATH"
 if [ -d "$FULL_COVERAGE_RESULTS_PATH" ]; then
   chmod -R a+r "$FULL_COVERAGE_RESULTS_PATH"
 else
-  echo "Coverage results directory does not exist. If you are expecting coverage results, please make sure the Code Coverage package is installed in your project and that it is set up correctly."
+  echo "Coverage results directory does not exist. If you are expecting coverage results, please make sure the Code Coverage package is installed in your unity project and that it is set up correctly."
 fi


### PR DESCRIPTION
Add check before performing `chmod` on the code coverage path, as it does not exist if the Code Coverage package is not installed, or is not set up correctly.

This was previously not done, causing me to spend a lot of time on trying to figure out why the action did not function as I expected it to.
I have also added a general message that gives some hints as to why the code coverage retrieval might not work.

#### Changes

- Added a check before performing `chmod` on the expected code coverage report path
- Added a general message to guide users when the path does not exist

#### Related Issues

- #218 
- #260 

#### Related PRs

- none

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run
of the workflows from your own repo.

- https://github.com/QuakeEye/unity-test-runner/actions/runs/8080679270

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
