### PR TITLE
fix(package-mode): scoped registry manifest conditional

### DIFF
--- a/dist/platforms/ubuntu/run_tests.sh
+++ b/dist/platforms/ubuntu/run_tests.sh
@@ -95,7 +95,7 @@ if [ "$PACKAGE_MODE" = "true" ]; then
   fi
 
   PACKAGE_MANIFEST_JSON=$(cat "$PACKAGE_MANIFEST_PATH")
-  if [ -z "$SCOPED_REGISTRY_URL" || -z "$REGISTRY_SCOPES" ]; then
+  if [ -z "$SCOPED_REGISTRY_URL" ] || [ -z "$REGISTRY_SCOPES" ]; then
     echo "$PACKAGE_MANIFEST_JSON" | \
       jq \
       --arg packageName "$PACKAGE_NAME" \


### PR DESCRIPTION
#### Changes

- fixes the bug introduced in #225 where an empty scoped registry is added to the `manifest.json` even when it is not supplied
- adds a conditional check to the jq argument that modifies the `manifest.json` to only include add the scoped registry when both the URL and Scopes are supplied.

#### Related Issues

- N/A

#### Related PRs

- N/A

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run
of the workflows from your own repo.

- https://github.com/luminopia/unity-test-runner/actions/runs/8285355477
- worth noting that while one of the tests failed in this run, it did correctly resolve the dependencies, however it encountered a license collision due to me not being able to acquire a personal license to test with.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
