### PR TITLE
feat: support private scoped registry on ubuntu

### DIFF
--- a/dist/platforms/ubuntu/run_tests.sh
+++ b/dist/platforms/ubuntu/run_tests.sh
@@ -37,6 +37,25 @@ echo "Using custom parameters $CUSTOM_PARAMETERS."
 echo "Using Unity version \"$UNITY_VERSION\" to test."
 
 #
+# Setup token for private package registry.
+#
+
+if [ -n "$PRIVATE_REGISTRY_TOKEN" ]; then
+  echo "Private registry token detected, creating .upmconfig.toml"
+
+  UPM_CONFIG_TOML_PATH="$HOME/.upmconfig.toml"
+  echo "Creating toml at path: $UPM_CONFIG_TOML_PATH"
+
+  touch $UPM_CONFIG_TOML_PATH
+
+  cat > "$UPM_CONFIG_TOML_PATH" <<EOF
+  [npmAuth."$SCOPED_REGISTRY_URL"]
+  token = "$PRIVATE_REGISTRY_TOKEN"
+  alwaysAuth = true
+EOF
+fi
+
+#
 # Create an empty project for testing if in package mode
 #
 
@@ -120,20 +139,6 @@ if [ "$PACKAGE_MODE" = "true" ]; then
 
   UNITY_PROJECT_PATH="$TEMP_PROJECT_PATH"
 
-  if [ -n "$PRIVATE_REGISTRY_TOKEN" ]; then
-    echo "Private registry token detected, creating .upmconfig.toml"
-
-    UPM_CONFIG_TOML_PATH="$HOME/.upmconfig.toml"
-    echo "Creating toml at path: $UPM_CONFIG_TOML_PATH"
-
-    touch $UPM_CONFIG_TOML_PATH
-
-    cat > "$UPM_CONFIG_TOML_PATH" <<EOF
-    [npmAuth."$SCOPED_REGISTRY_URL"]
-    token = "$PRIVATE_REGISTRY_TOKEN"
-    alwaysAuth = true
-EOF
-  fi
 
 fi
 


### PR DESCRIPTION
#### Changes

- Moves the creation of the `.upmconfig.toml` previously used for package testing, to outside the scope of package testing to support projects which contain private scoped registries. The caveats remain the same for packages, that right now it is only supported on Linux runners, and only a single  private registry is supported.

#### Related Issues

- Closes https://github.com/game-ci/unity-test-runner/issues/271

#### Related PRs

- Docs PR: https://github.com/game-ci/documentation/pull/470

#### Successful Workflow Run Link

PRs don't have access to secrets so you will need to provide a link to a successful run
of the workflows from your own repo.

- I have a successful run on a private repo, my fork fails the existing tests due to missing Unity License. If needed I could alter the `main.yml` to only run a single test on a Professional license to show it pass, or we could discuss any other options like sharing screenshots of action passing from private repo.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR
      in the [documentation repo](https://github.com/game-ci/documentation))
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
