### PR TITLE
Provide descriptive activation information on activation error with License Server

### DIFF
--- a/dist/platforms/ubuntu/activate.sh
+++ b/dist/platforms/ubuntu/activate.sh
@@ -65,7 +65,14 @@ elif [[ -n "$UNITY_LICENSING_SERVER" ]]; then
   FLOATING_LICENSE=$(sed -n 2p <<< "$PARSEDFILE")
   FLOATING_LICENSE_TIMEOUT=$(sed -n 4p <<< "$PARSEDFILE")
 
-  echo "Acquired floating license: \"$FLOATING_LICENSE\" with timeout $FLOATING_LICENSE_TIMEOUT"
+  if [[ -z "$FLOATING_LICENSE" || -z "$FLOATING_LICENSE_TIMEOUT" ]]; then
+    echo "::error ::Failed to acquire floating license from Unity Licensing Server."
+    echo "Check the activation log below for more details."
+    cat license.txt
+  else
+    echo "Acquired floating license: \"$FLOATING_LICENSE\" with timeout $FLOATING_LICENSE_TIMEOUT"
+  fi
+
   # Store the exit code from the verify command
 else
   #


### PR DESCRIPTION
When trying to activate using Unity.Licensing.Client, any errors will provide no output from the licensing client. This change makes sure to provide context as to why the Unity.Licensing.Client has failed to retrieve a license.

#### Changes

 - Check if activation with a License server was successful and provide complete output from Unity.Licensing.Client if it failed to retrieve a valid license.

#### Successful Workflow Run Link

My time is limited, and this is a very small and simple change. I cannot create a public Unity project repository and configure CI just for this. 

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [Not Needed] Docs (If new inputs or outputs have been added or changes to behavior that should be documented. Please make a PR in the [documentation repo](https://github.com/game-ci/documentation))
- [Not Needed] Readme (updated or not needed)
- [Not Needed] Tests (added, updated or not needed)
