### PR TITLE
fix: update action runtime from Node.js 20 to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,6 @@ branding:
   icon: 'box'
   color: 'gray-dark'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/main.js'
   post: 'dist/post.js'


### PR DESCRIPTION
#### Changes

- Update `action.yml` from `using: 'node20'` to `using: 'node24'`

#### Related Issues

- #303

#### Successful Workflow Run Link

- Tested on a private repository with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` set as a top-level env variable. All jobs passed: unit tests, builds for Windows/iOS/Android. We cannot link directly as the repo is private, but happy to share logs or screenshots if needed.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Docs (not needed - no new inputs/outputs)
- [x] Readme (not needed)
- [x] Tests (not needed - runtime change only, verified on private repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Action runtime environment from Node.js 20 to Node.js 24 for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->